### PR TITLE
Remove unnecessary patch line from .md5sum

### DIFF
--- a/awesome/.md5sum
+++ b/awesome/.md5sum
@@ -1,2 +1,1 @@
-60fb7d808e1d184483ca3e3db7e54727  awesome-3.5.7-input-fix.patch
 bdca8e1740cd9c5a76bfc46f8d943cf1  awesome-3.5.8.tar.xz


### PR DESCRIPTION
Get rid of .md5sum line for awesome-3.5.7-input-fix.patch. It causes an error when compiling awesome in Crux.
